### PR TITLE
Fixed path quoting and added examples

### DIFF
--- a/examples/hello.m
+++ b/examples/hello.m
@@ -1,0 +1,6 @@
+#import <stdio.h>
+
+int main( int argc, const char *argv[] ) {
+    printf( "hello world\n" );
+    return 0;
+}

--- a/examples/script with weird name.m
+++ b/examples/script with weird name.m
@@ -1,0 +1,6 @@
+#import <stdio.h>
+
+int main( int argc, const char *argv[] ) {
+    printf( "hello world\n" );
+    return 0;
+}

--- a/objc-run
+++ b/objc-run
@@ -6,10 +6,10 @@ then
 	exit 1
 fi
 
-filepath=$1
-filename=$(basename $filepath)
+filepath="$1"
+filename="$(basename "$filepath")"
 appname="${filename%.*}"
-dirname=$(dirname $filepath)
+dirname="$(dirname "$filepath")"
 shift
 
 # check if there's already a file with the same name as our compiled app, if so exit
@@ -20,8 +20,8 @@ then
 fi
 
 #remove first occurrence of '#!', as this is probably the shebang
-sed -e '/^#!\//,1d' $filepath > ${filepath}.objc-run-patched.m
-filepath=${filepath}.objc-run-patched.m
+sed -e '/^#!\//,1d' "$filepath" > "${filepath}.objc-run-patched.m"
+filepath="${filepath}.objc-run-patched.m"
 
 # compile the file
 clang -o "$dirname/$appname" -Wall -std=c99 "$filepath" -framework Foundation -lobjc -fobjc-arc


### PR DESCRIPTION
I've added a couple examples that can be used to testing the script.
I've fixed the quoting to solve problem like this:

$ ./objc-run examples/script\ with\ weird\ name.m                                                                                                       ~/objc-run  master@9c2cf33 ✗
usage: dirname path
./objc-run: line 23: ${filepath}.objc-run-patched.m: ambiguous redirect
clang: error: no such file or directory: 'examples/script with weird name.m.objc-run-patched.m'
objc-run usage: clang returned with error
