### PR TITLE
Allow objc-run to be installed anywhere

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -27,7 +27,7 @@ You can omit the explicit invocation of objc-run on the command line and launch 
 
 Just insert this as first line in your .m file:
 
-	#!/usr/bin/env /usr/bin/objc-run
+	#!/usr/bin/env objc-run
 	
 If you have installed objc-run in a directory different from /usr/bin, you'll need to adjust the path accordingly.
 

--- a/examples/CocoaPodsTest.m
+++ b/examples/CocoaPodsTest.m
@@ -1,4 +1,4 @@
-#!/usr/bin/env /usr/bin/objc-run
+#!/usr/bin/env objc-run
 
 /*
 podfile-start

--- a/examples/NSProcessInfoTest.m
+++ b/examples/NSProcessInfoTest.m
@@ -1,4 +1,4 @@
-#!/usr/bin/env /usr/bin/objc-run
+#!/usr/bin/env objc-run
 
 @import Foundation;
 

--- a/examples/hello.m
+++ b/examples/hello.m
@@ -1,4 +1,4 @@
-#!/usr/bin/env /usr/bin/objc-run
+#!/usr/bin/env objc-run
 
 #import <stdio.h>
 

--- a/examples/print-args.m
+++ b/examples/print-args.m
@@ -1,4 +1,4 @@
-#!/usr/bin/env /usr/bin/objc-run
+#!/usr/bin/env objc-run
 
 #import <stdio.h>
 

--- a/examples/script with weird name.m
+++ b/examples/script with weird name.m
@@ -1,4 +1,4 @@
-#!/usr/bin/env /usr/bin/objc-run
+#!/usr/bin/env objc-run
 #import <stdio.h>
 
 int main( int argc, const char *argv[] ) {


### PR DESCRIPTION
as long as it can be found in $PATH.
