### PR TITLE
Use Ruby 1.9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: objective-c
+rvm: 1.9.3
 install: /usr/bin/true
 script: ./test.bash


### PR DESCRIPTION
2.0.0 (the default) is currently missing CocoaPods.
