### PR TITLE
bugfix. correctly handles filenames with spaces

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: objective-c
-rvm: 1.9.3
+rvm: 2.0.0
 install: /usr/bin/true
 script: ./test.bash

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: objective-c
-rvm: 2.0.0
+rvm: 1.9.3
 install: /usr/bin/true
 script: ./test.bash

--- a/examples/CocoaPodsTest with weird name.m
+++ b/examples/CocoaPodsTest with weird name.m
@@ -1,0 +1,38 @@
+#!/usr/bin/env objc-run
+
+/*
+podfile-start
+platform :osx, '10.8'
+pod 'Barista'
+podfile-end
+*/
+
+#import <Foundation/Foundation.h>
+#import "Barista.h"
+#import "BARRouter.h"
+
+int main(int argc, const char * argv[])
+{
+	@autoreleasepool
+	{
+		BARServer *server = [BARServer serverWithPort:4242];
+		BARRouter *router = [[BARRouter alloc] init];
+		[router addRoute:@"/" forHTTPMethod:@"GET" handler:^BOOL(BARConnection *connection, BARRequest *request, NSDictionary *parameters) {
+			BARResponse *response = [[BARResponse alloc] init];
+			response.responseData = [@"Hello world" dataUsingEncoding:NSUTF8StringEncoding];
+			response.statusCode = 200;
+			[connection sendResponse:response];
+			return YES;
+		}];
+		[server addGlobalMiddleware:router];
+		[server startListening];
+		
+		if (![[[ NSProcessInfo processInfo] arguments] containsObject:@"-quit"])
+		{
+			while(YES){
+				[[NSRunLoop mainRunLoop] run];
+			}
+		}
+	}
+    return 0;
+}

--- a/objc-run
+++ b/objc-run
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+#set -xe
 function main
 {
 	if [[ $# -lt 1 ]]; then 
@@ -78,9 +78,9 @@ function handleSourceFileWithCocoaPods
 	awk 'NR>1 || !/^#!/' "$filepath" > "$projectDirPath/main.m"
 	
 	# extract embedded podfile and save it into projectdir
-	podstart=`awk '/podfile-start/{print NR+1}' $filepath`
-	podend=`awk '/podfile-end/{print NR-1}' $filepath`
-	sed -n ${podstart},${podend}p $filepath > "$projectDirPath/Podfile.new"
+	podstart=`awk '/podfile-start/{print NR+1}' "$filepath"`
+	podend=`awk '/podfile-end/{print NR-1}' "$filepath"`
+	sed -n ${podstart},${podend}p "$filepath" > "$projectDirPath/Podfile.new"
 	
 	(
 		cd "$projectDirPath"

--- a/objc-run
+++ b/objc-run
@@ -107,7 +107,7 @@ function handleSourceFileWithCocoaPods
 
 	# on clang success, run compiled application and remove it
 	if [[ $xcodebuildExitCode -eq 0 ]]; then 
-		cp "$projectDirPath/build/usr/local/bin/clitest" $target
+		cp "$projectDirPath/build/usr/local/bin/clitest" "$target"
 		trap '{ rm -f "$target" ; exit 1; }' INT
 		"$target" "$@"
 		trap '' INT

--- a/objc-run
+++ b/objc-run
@@ -1,5 +1,5 @@
 #!/bin/bash
-#set -xe
+
 function main
 {
 	if [[ $# -lt 1 ]]; then 
@@ -67,8 +67,9 @@ function handleSourceFileWithCocoaPods
 	fi
 	
 	# check if a  temporary project directory already exists, if not create it
+        selfScriptHash=`md5 -q $BASH_SOURCE`
 	sourcePathHash=`md5 -qs "$filepath"`
-	projectDirPath="${TMPDIR}objc-run/$sourcePathHash"
+	projectDirPath="${TMPDIR}objc-run/$selfScriptHash/$sourcePathHash"
 	if [ ! -d $projectDirPath ]
 	then
 		createProjectDirectory "$projectDirPath"

--- a/test.bash
+++ b/test.bash
@@ -19,6 +19,7 @@ logExit () {
  EXISTSOUT="objc-run: file already exists at /when-file-already-exists ... exiting"
   PODTEST1="examples/MACollectionUtilitiesTest.m"
   PODTEST2="examples/CocoaPodsTest.m"
+  PODTEST3="examples/CocoaPodsTest with weird name.m"
 
 logC "Testing output of $HELLO is $HELLOOUT"
 diff <( objc-run $HELLO ) - << EOF
@@ -52,6 +53,9 @@ if which pod >/dev/null; then
     logC "Running CocoaPods Test 2 ... $PODTEST2 (with xcodebuild output supressed)"
     objc-run $PODTEST2 -quit > /dev/null
     logExit $? $PODTEST2
+    logC "Running CocoaPods Test 3 ... $PODTEST3 (with xcodebuild output supressed)"
+    objc-run "$PODTEST3" -quit > /dev/null
+    logExit $? $PODTEST3
 fi
 
 logC "All tests passed! Done." 6


### PR DESCRIPTION
Previously, if a file had a space in its filename and used cocoapods,
then objc-run would fail to build it correctly, as a result of trying to
copy to the unescaped filename, so that it copied only to the first
token of the filename.

This commit fixes that by wrapping the filename in quotes.
